### PR TITLE
feat: rename the 'novu' package to 'novu-python'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Novu Client (Python)
 
-[![PyPI](https://img.shields.io/pypi/v/novu?color=blue)](https://pypi.org/project/novu/)
+[![PyPI](https://img.shields.io/pypi/v/novu-python?color=blue)](https://pypi.org/project/novu-python/)
 ![Tests Status](https://github.com/SpikeeLabs/novu-python/actions/workflows/.github/workflows/tests.yml/badge.svg)
 [![codecov](https://codecov.io/gh/SpikeeLabs/novu-python/branch/main/graph/badge.svg?token=RON7F8QTZX)](https://codecov.io/gh/SpikeeLabs/novu-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/novu)
-![PyPI - License](https://img.shields.io/pypi/l/novu)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/novu-python)
+![PyPI - License](https://img.shields.io/pypi/l/novu-python)
 [![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 
 ---
@@ -20,10 +20,10 @@ To install this package
 
 ```shell
 # Via pip
-pip install novu
+pip install novu-python
 
 # Via poetry
-poetry add novu
+poetry add novu-python
 ```
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 This project aims to provide a python wrapper for the Novu API.
 
+> :warning: **This deposit is not officially maintained by [novuhq](https://github.com/novuhq).** The Novu software development team is currently (March 2023) thinking of using the [ferns](https://www.buildwithfern.com/) solution to create an SDK for all languages for easier maintenance. For more details on the subject or to follow the progress on the official SDK support, you can check the issue https://github.com/novuhq/novu/issues/2835.
+
 ## Install
 
 To install this package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 description = "This project aims to provide a wrapper for the Novu API."
 keywords = ["novu", "python", "sdk", "api", "wrapper"]
-name = "novu"
+name = "novu-python"
 version = "1.0.0"
 
 documentation = "https://novu-python.readthedocs.io/en/latest"


### PR DESCRIPTION
Ask requested by novuhq in https://github.com/novuhq/novu/issues/2835, we move the package to rename it 'novu-python' so that they can keep this name in the scenario where they use Ferns to publish officially supported packages on several programming languages.